### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM php:7.4-cli-buster
+
+RUN apt-get update && apt-get install -y git
+
+RUN curl -s https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
+
+COPY . /app
+WORKDIR /app
+
+RUN composer install
+
+CMD [ "php", "index.php" ]


### PR DESCRIPTION
Add Dockerfile for the convenience. 
I think using Docker is the most clean & easy way to use the tool without a manual setup.

## Usage

```
$ docker build -t doeobfuscator .
$ docker container run -it --rm --volume=/tmp:/tmp doeobfuscator -f /tmp/path/to/file.php 
```