### PR TITLE
Fix 0 vs null index in array assign

### DIFF
--- a/src/ValRef/ScalarValue.php
+++ b/src/ValRef/ScalarValue.php
@@ -36,7 +36,7 @@ class ScalarValue extends AbstractValRef
 
     public function arrayAssign($dim, ValRef $valRef)
     {
-        if ($dim == null) {
+        if ($dim === null) {
             $this->value[] = $valRef->getValue();
         } else {
             $this->value[$dim] = $valRef->getValue();


### PR DESCRIPTION
There seems to be a problem with assignment to the zero index in an array. 
Here is a minimal example:

```
$s = "0a";
$s[0] = 0;
```

For me this generated "Uncaught Error: [] operator not supported for strings" (src/ValRef/ScalarValue.php:40) 

After some digging this seems to be a confusion between `$array[] = 0` (append zero to array) and `$array[0] = 0` (update value at index 0). 

I believe the fix is simply to differentiate between 0 and null. 

P.S. Thanks for this amazing project! 




