### PR TITLE
Added two PassThrough functions used in malware samples, convert_uudecode and hex2bin

### DIFF
--- a/src/Reducer/FuncCallReducer/PassThrough.php
+++ b/src/Reducer/FuncCallReducer/PassThrough.php
@@ -32,6 +32,8 @@ class PassThrough implements FunctionReducer
             'strtr',
             'substr',
             'urldecode',
+            'convert_uudecode',
+            'hex2bin',
         );
     }
 


### PR DESCRIPTION
Saw that some malware use `convert_uudecode` and `hex2bin` to obfuscate the code. 
I've added these two. 